### PR TITLE
N5 Adaptors for groupspec and arrayspec

### DIFF
--- a/src/fibsem_tools/io/multiscale.py
+++ b/src/fibsem_tools/io/multiscale.py
@@ -24,7 +24,7 @@ multiscale_metadata_types = ["neuroglancer", "cellmap", "cosem", "ome-ngff"]
 def multiscale_group(
     arrays: Sequence[DataArray],
     metadata_types: List[str],
-    array_paths: Union[List[str], Literal["auto"]] = "auto",
+    array_paths: Union[Sequence[str], Literal["auto"]] = "auto",
     chunks: Union[Tuple[Tuple[int, ...], ...], Literal["auto"]] = "auto",
     name: Optional[str] = None,
     **kwargs,

--- a/tests/test_zarr.py
+++ b/tests/test_zarr.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, Callable, Dict, Literal, Optional, Tuple, Union
 from datatree import DataTree
 import pytest
 from xarray import DataArray
@@ -21,20 +22,25 @@ from fibsem_tools.io.zarr import (
     get_url,
     to_dask,
     to_xarray,
+    n5_array_unwrapper,
+    n5_spec_wrapper,
+    n5_spec_unwrapper,
 )
 from fibsem_tools.metadata.transform import STTransform
 import dask.array as da
 from xarray.testing import assert_equal
+from pydantic_zarr import GroupSpec
+from numcodecs import GZip
 
 
-def test_url(temp_zarr):
+def test_url(temp_zarr: str) -> None:
     store = FSStore(temp_zarr)
     group = zarr.group(store)
     arr = group.create_dataset(name="foo", data=np.arange(10))
     assert get_url(arr) == f"file://{store.path}/foo"
 
 
-def test_read_xarray(temp_zarr):
+def test_read_xarray(temp_zarr: str) -> None:
     path = "test"
     url = os.path.join(temp_zarr, path)
 
@@ -74,7 +80,13 @@ def test_read_xarray(temp_zarr):
 @pytest.mark.parametrize("coords", ("auto",))
 @pytest.mark.parametrize("use_dask", (True, False))
 @pytest.mark.parametrize("name", (None, "foo"))
-def test_read_datatree(temp_zarr, attrs, coords, use_dask, name):
+def test_read_datatree(
+    temp_zarr: str,
+    attrs: Optional[Dict[str, Any]],
+    coords: str,
+    use_dask: bool,
+    name: Optional[str],
+) -> None:
     path = "test"
     os.path.join(temp_zarr, path)
     base_data = np.zeros((10, 10, 10))
@@ -156,7 +168,13 @@ def test_read_datatree(temp_zarr, attrs, coords, use_dask, name):
 @pytest.mark.parametrize("coords", ("auto",))
 @pytest.mark.parametrize("use_dask", (True, False))
 @pytest.mark.parametrize("name", (None, "foo"))
-def test_read_dataarray(temp_zarr, attrs, coords, use_dask, name):
+def test_read_dataarray(
+    temp_zarr: str,
+    attrs: Optional[Dict[str, Any]],
+    coords: str,
+    use_dask: bool,
+    name: Optional[str],
+) -> None:
     path = "test"
     data = stt_from_array(
         np.zeros((10, 10, 10)),
@@ -203,14 +221,14 @@ def test_read_dataarray(temp_zarr, attrs, coords, use_dask, name):
         assert dict(data_store.attrs) == attrs
 
 
-def test_access_array_zarr(temp_zarr):
+def test_access_array_zarr(temp_zarr: str) -> None:
     data = np.random.randint(0, 255, size=(100,), dtype="uint8")
     z = zarr.open(temp_zarr, mode="w", shape=data.shape, chunks=10)
     z[:] = data
     assert np.array_equal(access_zarr(temp_zarr, "", mode="r")[:], data)
 
 
-def test_access_array_n5(temp_n5):
+def test_access_array_n5(temp_n5: str) -> None:
     data = np.random.randint(0, 255, size=(100,), dtype="uint8")
     z = zarr.open(temp_n5, mode="w", shape=data.shape, chunks=10)
     z[:] = data
@@ -218,7 +236,7 @@ def test_access_array_n5(temp_n5):
 
 
 @pytest.mark.parametrize("accessor", (access_zarr, access_n5))
-def test_access_group(temp_zarr, accessor):
+def test_access_group(temp_zarr: str, accessor: Callable[[Any], None]) -> None:
     if accessor == access_zarr:
         default_store = DEFAULT_ZARR_STORE
     elif accessor == access_n5:
@@ -236,7 +254,7 @@ def test_access_group(temp_zarr, accessor):
 
 
 @pytest.mark.parametrize("chunks", ("auto", (10,)))
-def test_dask(temp_zarr, chunks):
+def test_dask(temp_zarr: str, chunks: Union[Literal["auto"], Tuple[int, ...]]) -> None:
     path = "foo"
     data = np.arange(100)
     zarray = access_zarr(temp_zarr, path, mode="w", shape=data.shape, dtype=data.dtype)
@@ -257,7 +275,11 @@ def test_dask(temp_zarr, chunks):
     "store_class", (zarr.N5Store, zarr.DirectoryStore, zarr.NestedDirectoryStore)
 )
 @pytest.mark.parametrize("shape", ((10,), (10, 11, 12)))
-def test_chunk_keys(tmp_path: Path, store_class, shape):
+def test_chunk_keys(
+    tmp_path: Path,
+    store_class: Union[zarr.N5Store, zarr.DirectoryStore, zarr.NestedDirectoryStore],
+    shape: Tuple[int, ...],
+) -> None:
     store: zarr.storage.BaseStore = store_class(tmp_path)
     arr_path = "test"
     arr = zarr.create(
@@ -271,3 +293,27 @@ def test_chunk_keys(tmp_path: Path, store_class, shape):
     )
     observed = tuple(get_chunk_keys(arr))
     assert observed == expected
+
+
+def test_n5_wrapping(temp_n5: str) -> None:
+    group = zarr.group(zarr.N5Store(temp_n5), path="group1")
+    group.attrs.put({"group": "true"})
+    compressor = GZip(-1)
+    arr = group.create_dataset(
+        name="array", shape=(10, 10, 10), compressor=compressor, dimension_separator="/"
+    )
+    arr.attrs.put({"array": True})
+
+    spec_n5 = GroupSpec.from_zarr(group)
+    assert spec_n5.members["array"].dimension_separator == "."
+    arr_unwrapped = n5_array_unwrapper(spec_n5.members["array"])
+    assert arr_unwrapped.dimension_separator == "/"
+    assert arr_unwrapped.compressor == compressor.get_config()
+
+    spec_unwrapped = n5_spec_unwrapper(spec_n5)
+    assert spec_unwrapped.attrs == spec_n5.attrs
+    assert spec_unwrapped.members["array"] == arr_unwrapped
+
+    spec_wrapped = n5_spec_wrapper(spec_unwrapped)
+    group2 = spec_wrapped.to_zarr(group.store, path="group2")
+    assert GroupSpec.from_zarr(group2) == spec_n5


### PR DESCRIPTION
Add functions for transforming GroupSpec / ArraySpec instances into forms that can be stored with `N5FSStore`