### PR TITLE
fix n5_wrappers and narrow allowed dimension separator for neuroglancer n5 group

### DIFF
--- a/src/fibsem_tools/io/zarr.py
+++ b/src/fibsem_tools/io/zarr.py
@@ -596,8 +596,9 @@ def n5_group_wrapper(spec: GroupSpec) -> GroupSpec:
         if hasattr(member, "shape"):
             new_members[key] = n5_array_wrapper(member)
         else:
-            new_members[key] = n5_spec_wrapper(member)
-    return GroupSpec(attrs=spec.attrs, members=new_members)
+            new_members[key] = n5_group_wrapper(member)
+
+    return spec.__class__(attrs=spec.attrs, members=new_members)
 
 
 def n5_array_wrapper(spec: ArraySpec) -> ArraySpec:
@@ -620,7 +621,7 @@ def n5_array_wrapper(spec: ArraySpec) -> ArraySpec:
         raise ValueError(
             "N5 storage is not compatible with the '.' dimension separator"
         )
-    return ArraySpec(**{**spec.dict(), **dict(dimension_separator="/")})
+    return spec.__class__(**{**spec.dict(), **dict(dimension_separator="/")})
 
 
 def n5_array_unwrapper(spec: ArraySpec) -> ArraySpec:
@@ -641,7 +642,7 @@ def n5_array_unwrapper(spec: ArraySpec) -> ArraySpec:
     new_attributes = dict(
         compressor=spec.compressor["compressor_config"], dimension_separator="/"
     )
-    return ArraySpec(**{**spec.dict(), **new_attributes})
+    return spec.__class__(**{**spec.dict(), **new_attributes})
 
 
 def n5_group_unwrapper(spec: GroupSpec) -> GroupSpec:
@@ -666,7 +667,7 @@ def n5_group_unwrapper(spec: GroupSpec) -> GroupSpec:
             new_members[key] = n5_array_unwrapper(member)
         else:
             new_members[key] = n5_group_unwrapper(member)
-    return GroupSpec(attrs=spec.attrs, members=new_members)
+    return spec.__class__(attrs=spec.attrs, members=new_members)
 
 
 @overload

--- a/src/fibsem_tools/metadata/neuroglancer.py
+++ b/src/fibsem_tools/metadata/neuroglancer.py
@@ -129,12 +129,16 @@ class NeuroglancerN5Group(GroupSpec):
     def from_xarrays(
         cls,
         arrays: Iterable[DataArray],
-        chunks: Union[tuple[tuple[int, ...]], Literal["auto"]],
+        chunks: Union[tuple[int, ...], tuple[tuple[int, ...]], Literal["auto"]],
         **kwargs,
     ) -> "NeuroglancerN5Group":
 
         _chunks = normalize_chunks(arrays, chunks)
-
+        if "dimension_separator" in kwargs and kwargs.get("dimension_separator") == ".":
+            raise ValueError(
+                'Arrays stored in N5 must have dimension_separator set to "/"'
+            )
+        kwargs["dimension_separator"] = "/"
         array_specs = {
             f"s{idx}": ArraySpec.from_array(arr, chunks=cnks, **kwargs)
             for idx, arr, cnks in zip(range(len(arrays)), arrays, _chunks)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -17,9 +17,10 @@ from fibsem_tools.metadata.neuroglancer import (
 )
 from fibsem_tools.metadata.transform import STTransform
 import pytest
+from xarray_multiscale import multiscale, windowed_mean
 
 
-def test_sttransform():
+def test_sttransform() -> None:
     coords = [
         DataArray(np.arange(10), dims=("z")),
         DataArray(np.arange(10) + 5, dims=("y",), attrs={"units": "m"}),
@@ -47,7 +48,7 @@ def test_sttransform():
     )
 
 
-def test_neuroglancer_metadata():
+def test_neuroglancer_metadata() -> None:
     coords = [
         DataArray(np.arange(16) + 0.5, dims=("z"), attrs={"units": "nm"}),
         DataArray(np.arange(16) + 1 / 3, dims=("y",), attrs={"units": "m"}),
@@ -55,11 +56,8 @@ def test_neuroglancer_metadata():
     ]
 
     data = DataArray(np.zeros((16, 16, 16)), coords=coords)
-    coarsen_kwargs = {"z": 2, "y": 2, "x": 2, "boundary": "trim"}
-    multi = [data]
 
-    for idx in range(3):
-        multi.append(multi[-1].coarsen(**coarsen_kwargs).mean())
+    multi = multiscale(data, windowed_mean, (2, 2, 2))
 
     neuroglancer_metadata = NeuroglancerN5GroupMetadata.from_xarrays(multi)
 
@@ -73,11 +71,14 @@ def test_neuroglancer_metadata():
     spec = NeuroglancerN5Group.from_xarrays(multi, chunks=(16, 16, 16))
     assert spec.attrs == neuroglancer_metadata
     assert tuple(spec.members.keys()) == ("s0", "s1", "s2", "s3")
+    assert spec.members["s0"].dimension_separator == "/"
+
+    with pytest.raises(ValueError):
+        NeuroglancerN5Group.from_xarrays(multi, chunks="auto", dimension_separator=".")
 
 
 @pytest.mark.parametrize("version", ("v1", "v2"))
-def test_cosem(version: Literal["v1", "v2"]):
-
+def test_cosem(version: Literal["v1", "v2"]) -> None:
     transform_base = {
         "axes": ["z", "y", "x"],
         "units": ["nm", "m", "km"],

--- a/tests/test_zarr.py
+++ b/tests/test_zarr.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import zarr
 import numpy as np
 import itertools
+from xarray_multiscale import multiscale, windowed_mean
 from fibsem_tools.io.core import read_dask, read_xarray
 from fibsem_tools.io.multiscale import multiscale_group
 from fibsem_tools.io.xr import stt_from_array
@@ -26,6 +27,7 @@ from fibsem_tools.io.zarr import (
     n5_spec_wrapper,
     n5_spec_unwrapper,
 )
+from fibsem_tools.metadata.neuroglancer import NeuroglancerN5Group
 from fibsem_tools.metadata.transform import STTransform
 import dask.array as da
 from xarray.testing import assert_equal
@@ -317,3 +319,9 @@ def test_n5_wrapping(temp_n5: str) -> None:
     spec_wrapped = n5_spec_wrapper(spec_unwrapped)
     group2 = spec_wrapped.to_zarr(group.store, path="group2")
     assert GroupSpec.from_zarr(group2) == spec_n5
+
+    # test with N5 metadata
+    test_data = np.zeros((10, 10, 10))
+    multi = multiscale(test_data, windowed_mean, (2, 2, 2))
+    n5_neuroglancer_spec = NeuroglancerN5Group.from_xarrays(multi, chunks="auto")
+    assert n5_spec_wrapper(n5_neuroglancer_spec)


### PR DESCRIPTION
ignore the name of the branch