### PR TITLE
fix: correct behavior of normalize_chunks

### DIFF
--- a/src/fibsem_tools/io/util.py
+++ b/src/fibsem_tools/io/util.py
@@ -177,7 +177,8 @@ def normalize_chunks(
             if arr.chunks is None:
                 result += (arr.shape,)
             else:
-                result += (arr.chunks,)
+                # use the chunksize property of the underlying dask array
+                result += (arr.data.chunksize,)
     elif all(isinstance(c, tuple) for c in chunks):
         result = chunks
     else:

--- a/tests/test_multiscale.py
+++ b/tests/test_multiscale.py
@@ -13,7 +13,7 @@ import zarr
     "metadata_types",
     [("ome-ngff@0.4",), ("neuroglancer",), ("ome-ngff",), ("ome-ngff", "neuroglancer")],
 )
-def test_multiscale_storage(temp_zarr, metadata_types: Tuple[str, ...]):
+def test_multiscale_storage(temp_zarr: str, metadata_types: Tuple[str, ...]) -> None:
     data = da.random.randint(0, 8, (16, 16, 16), chunks=(8, 8, 8), dtype="uint8")
     store = zarr.NestedDirectoryStore(temp_zarr)
     coords = [

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,4 @@
+from typing import Literal, Tuple, Union
 import pytest
 import dask.array as da
 from xarray import DataArray
@@ -5,13 +6,15 @@ from fibsem_tools.io.util import normalize_chunks
 
 
 @pytest.mark.parametrize("chunks", ("auto", (3, 3, 3), ((3, 3, 3), (3, 3, 3))))
-def test_normalize_chunks(chunks):
+def test_normalize_chunks(
+    chunks: Union[Literal["auto"], Tuple[int, ...], Tuple[Tuple[int, ...], ...]]
+) -> None:
     arrays = DataArray(da.zeros((10, 10, 10), chunks=(4, 4, 4))), DataArray(
         da.zeros((5, 5, 5), chunks=(2, 2, 2))
     )
     observed = normalize_chunks(arrays, chunks)
     if chunks == "auto":
-        assert observed == (arrays[0].chunks, arrays[1].chunks)
+        assert observed == (arrays[0].data.chunksize, arrays[1].data.chunksize)
     elif isinstance(chunks[0], int):
         assert observed == (chunks,) * len(arrays)
     else:


### PR DESCRIPTION
previously, `normalize_chunks` with the `chunks` parameter set to `auto` would set the output chunks to the `.chunks` property of the input `DataArrays`, but this is wrong because the `.chunks` property is a collection of explicit chunks, not a chunk size. this PR fixes this by getting the chunksize from the `.data.chunksize` attribute of the input `DataArrays`