### PR TITLE
fix for being unable to read root group of hdf5

### DIFF
--- a/src/fibsem_tools/io/core.py
+++ b/src/fibsem_tools/io/core.py
@@ -268,7 +268,7 @@ def split_by_suffix(uri: PathLike, suffixes: Sequence[str]) -> tuple[str, str, s
 
     index = [idx for idx, val in enumerate(suffixed) if val][-1]
     if index == (len(parts) - 1):
-        pre, post = subpath, ""
+        pre, post = subpath, "/"
     else:
         pre, post = (
             separator.join([p.strip(separator) for p in parts[: index + 1]]),

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -33,7 +33,7 @@ def test_path_splitting():
 
     path = os.path.join("0", "1", "2.n5")
     split = split_by_suffix(path, (".n5",))
-    assert split == (os.path.join("0", "1", "2.n5"), "", ".n5")
+    assert split == (os.path.join("0", "1", "2.n5"), "/", ".n5")
 
 
 @pytest.mark.parametrize("fmt", ["zarr", "n5"])

--- a/tests/io/test_h5.py
+++ b/tests/io/test_h5.py
@@ -3,7 +3,7 @@ import os
 import h5py
 import numpy as np
 
-from fibsem_tools.io.h5 import access
+from fibsem_tools.io.core import access
 
 
 def test_access_array(tmpdir):
@@ -16,12 +16,12 @@ def test_access_array(tmpdir):
         arr1 = h5f.create_dataset(key, data=data)
         arr1.attrs.update(**attrs)
 
-    arr2 = access(path, key, mode="r")
+    arr2 = access(os.path.join(path, key), mode="r")
     assert dict(arr2.attrs) == attrs
     assert np.array_equal(arr2[:], data)
     arr2.file.close()
 
-    arr3 = access(path, key, data=data, attrs=attrs, mode="w")
+    arr3 = access(os.path.join(path, key), data=data, attrs=attrs, mode="w")
     assert dict(arr3.attrs) == attrs
     assert np.array_equal(arr3[:], data)
     arr3.file.close()
@@ -29,13 +29,19 @@ def test_access_array(tmpdir):
 
 def test_access_group(tmpdir):
     key = "s0"
-    store = os.path.join(str(tmpdir), key)
+    tmpfile = "test.h5"
+    store = os.path.join(str(tmpdir), tmpfile)
+
     attrs = {"resolution": "1000"}
 
-    grp = access(store, key, attrs=attrs, mode="w")
+    grp = access(os.path.join(store, key), attrs=attrs, mode="w")
     assert dict(grp.attrs) == attrs
     grp.file.close()
 
-    grp2 = access(store, key, mode="r")
+    grp2 = access(os.path.join(store, key), mode="r")
     assert dict(grp2.attrs) == attrs
     grp2.file.close()
+
+    root_grp = access(store, mode="r")
+    assert key in root_grp
+    root_grp.file.close()

--- a/tests/io/test_mrc.py
+++ b/tests/io/test_mrc.py
@@ -6,10 +6,9 @@ import pytest
 from xarray.testing import assert_equal
 
 from fibsem_tools.coordinate import stt_array
-from fibsem_tools.io.core import read_xarray
+from fibsem_tools.io.core import read_xarray, access
 from fibsem_tools.io.mrc import (
     MrcArrayWrapper,
-    access,
     recarray_to_dict,
     to_dask,
     to_xarray,

--- a/tests/io/test_tif.py
+++ b/tests/io/test_tif.py
@@ -7,7 +7,7 @@ import pytest
 import tifffile
 
 from fibsem_tools import read
-from fibsem_tools.io.tif import access
+from fibsem_tools.core import access
 
 
 @pytest.mark.parametrize("file_name", ["test.tif", "test.tiff"])

--- a/tests/io/test_tif.py
+++ b/tests/io/test_tif.py
@@ -7,7 +7,7 @@ import pytest
 import tifffile
 
 from fibsem_tools import read
-from fibsem_tools.core import access
+from fibsem_tools.io.core import access
 
 
 @pytest.mark.parametrize("file_name", ["test.tif", "test.tiff"])


### PR DESCRIPTION
Currently reading an hdf5 file directly, i.e. `read("myfile.h5")` throws an error:
```ValueError: Unable to synchronously create group (name parameter cannot be an empty string)```
I expect it to return the HDF5 group at the file's root.

This PR:
- adds testing for the above
- changes tests for other file formats to use `access` from core (so that it's before path splitting)
- changes `split_by_suffix` to return `"/"` as the subpath if the path ends in one of the known suffixes
- changes the test for path splitting to account for the change in behavior